### PR TITLE
Fix aeson-pretty version to 0.7.2 or earlier.

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -4,4 +4,4 @@ packages:
 extra-deps:
 - attoparsec-binary-0.2
 - binary-bits-0.5
-resolver: lts-3.15
+resolver: lts-6.14

--- a/wayland-tracker.cabal
+++ b/wayland-tracker.cabal
@@ -24,6 +24,6 @@ executable wayland-tracker
   build-depends:       base, mtl, stm, network, unix, bytestring, xml,
                        containers, binary-bits >= 0.3, cmdargs, utf8-string,
                        attoparsec, attoparsec-binary, time, aeson,
-                       base16-bytestring, cpu, binary, aeson-pretty
+                       base16-bytestring, cpu, binary, aeson-pretty <= 0.7.2
   hs-source-dirs:      ., cbits, src
   default-language:    Haskell2010


### PR DESCRIPTION
Fixes https://github.com/01org/wayland-tracker/issues/1 by fixing aeson-pretty version to be <= 0.7.2. The version can be bumped as soon as a stack LTS release supports aeson-pretty 0.8.1 or later.
