### PR TITLE
Change to aeson-pretty >= 0.8.1

### DIFF
--- a/src/Log.hs
+++ b/src/Log.hs
@@ -163,5 +163,5 @@ writeLog (Logger lh lt) ts msg = do
             BS.hPut lh bNewLine
             IO.hFlush lh
     where
-        conf = AP.Config 4 ordering
+        conf = AP.Config (AP.Spaces 4) ordering AP.Generic
         ordering = AP.keyOrder ["type", "name", "object", "interface", "arguments", "value", "message", "timestamp"]

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,4 @@
 flags: {}
 packages:
 - '.'
-extra-deps:
-- attoparsec-binary-0.2
-- binary-bits-0.5
-resolver: lts-6.14
+resolver: lts-7.0

--- a/wayland-tracker.cabal
+++ b/wayland-tracker.cabal
@@ -24,6 +24,6 @@ executable wayland-tracker
   build-depends:       base, mtl, stm, network, unix, bytestring, xml,
                        containers, binary-bits >= 0.3, cmdargs, utf8-string,
                        attoparsec, attoparsec-binary, time, aeson,
-                       base16-bytestring, cpu, binary, aeson-pretty <= 0.7.2
+                       base16-bytestring, cpu, binary, aeson-pretty >= 0.8.1
   hs-source-dirs:      ., cbits, src
   default-language:    Haskell2010


### PR DESCRIPTION
The `aeson-pretty` API was changed. Use the new API now that stack has an LTS resolver that includes `aeson-pretty` 0.8.2.
